### PR TITLE
Error handling

### DIFF
--- a/roboticsrov/bin/roboticsrov-test
+++ b/roboticsrov/bin/roboticsrov-test
@@ -6,37 +6,27 @@ from roboticsnet.rover_listener import RoverListener
 from roboticsnet.command_hook import CommandHook
 
 import roboticsrov
+from roboticsrov.rover_constants import *
 from roboticsrov.stream.video_stream import VideoStream 
 from roboticsrov.umanager import UManager 
 
-
-ard = True
+hookString = ""
 
 try:
     webcam_stream = VideoStream('/dev/video0',8081)
+    hookString += generate_webcam_hook_string("webcam_stream")
 except Exception as e:
     print e.message
 
 try:
     uManager = UManager()
-    cmdHook = CommandHook(
-        forward=uManager.forward,
-        reverse=uManager.reverse,  
-        forwardLeft=uManager.forwardLeft,
-        forwardRight=uManager.forwardRight,
-        reverseLeft=uManager.reverseLeft,
-        reverseRight=uManager.reverseRight,
-        stop=uManager.stop,
-        startVideo=webcam_stream.start,
-        stopVideo=webcam_stream.end)
+    hookString += generate_motor_hook_string("uManager")
 except Exception as e:
     print e.message
-    cmdHook = CommandHook(
-        startVideo=webcam_stream.start,
-        stopVideo=webcam_stream.end)
-    
 
+print "Starting server with hooks:\n" + hookString
 
+cmdHook = CommandHook(hookString)
 server = RoverListener(hooks=cmdHook)
 
 print roboticsrov.__appname__, " ", roboticsrov.__version__

--- a/roboticsrov/bin/roboticsrov-test
+++ b/roboticsrov/bin/roboticsrov-test
@@ -26,7 +26,7 @@ except Exception as e:
 
 print "Starting server with hooks:\n" + hookString
 
-cmdHook = CommandHook(hookString)
+exec("cmdHook = CommandHook(" + hookString + ")")
 server = RoverListener(hooks=cmdHook)
 
 print roboticsrov.__appname__, " ", roboticsrov.__version__

--- a/roboticsrov/bin/roboticsrov-test
+++ b/roboticsrov/bin/roboticsrov-test
@@ -9,26 +9,33 @@ import roboticsrov
 from roboticsrov.stream.video_stream import VideoStream 
 from roboticsrov.umanager import UManager 
 
-try:
-    uManager = UManager()
-except Exception as e:
-    print e.message
-    
+
+ard = True
+
 try:
     webcam_stream = VideoStream('/dev/video0',8081)
 except Exception as e:
     print e.message
 
-cmdHook = CommandHook(
-    forward=uManager.forward,
-    reverse=uManager.reverse,  
-    forwardLeft=uManager.forwardLeft,
-    forwardRight=uManager.forwardRight,
-    reverseLeft=uManager.reverseLeft,
-    reverseRight=uManager.reverseRight,
-    stop=uManager.stop,
-    startVideo=webcam_stream.start,
-    stopVideo=webcam_stream.end)
+try:
+    uManager = UManager()
+    cmdHook = CommandHook(
+        forward=uManager.forward,
+        reverse=uManager.reverse,  
+        forwardLeft=uManager.forwardLeft,
+        forwardRight=uManager.forwardRight,
+        reverseLeft=uManager.reverseLeft,
+        reverseRight=uManager.reverseRight,
+        stop=uManager.stop,
+        startVideo=webcam_stream.start,
+        stopVideo=webcam_stream.end)
+except Exception as e:
+    print e.message
+    cmdHook = CommandHook(
+        startVideo=webcam_stream.start,
+        stopVideo=webcam_stream.end)
+    
+
 
 server = RoverListener(hooks=cmdHook)
 

--- a/roboticsrov/roboticsrov_exception.py
+++ b/roboticsrov/roboticsrov_exception.py
@@ -1,4 +1,4 @@
-class RoboticsbaseException(Exception):
+class RoboticsrovException(Exception):
     """
     Exception class for roboticsbase
     author: mark

--- a/roboticsrov/rover_constants.py
+++ b/roboticsrov/rover_constants.py
@@ -3,17 +3,10 @@ def generate_webcam_hook_string(object_name):
 
 def generate_motor_hook_string(object_name):
     return "forward=" +\
-       object_name +\
-       ".forward,\nreverse=" +\
-       object_name +\
-       ".reverse,\nforwardLeft=" +\
-       object_name +\
-       ".forwardLeft,\nforwardRight=" +\
-       object_name +\
-       ".forwardRight,\nreverseLeft=" +\
-       object_name +\
-       ".reverseLeft,\nreverseRight=" +\
-       object_name +\
-       ".reverseRight,\nstop=" +\
-       object_name +\
-       ".stop,\n"
+       object_name + ".forward,\nreverse=" +\
+       object_name + ".reverse,\nforwardLeft=" +\
+       object_name + ".forwardLeft,\nforwardRight=" +\
+       object_name + ".forwardRight,\nreverseLeft=" +\
+       object_name + ".reverseLeft,\nreverseRight=" +\
+       object_name + ".reverseRight,\nstop=" +\
+       object_name + ".stop,\n"

--- a/roboticsrov/rover_constants.py
+++ b/roboticsrov/rover_constants.py
@@ -2,4 +2,18 @@ def generate_webcam_hook_string(object_name):
     return "startVideo=" + object_name + ".start,\nstopVideo=" + object_name + ".end,\n"
 
 def generate_motor_hook_string(object_name):
-    return "forward=" + object_name + ".forward,\nreverse=" + object_name + ".reverse,\nforwardLeft=" + object_name + ".forwardLeft,\nforwardRight=" + object_name + ".forwardRight,\nreverseLeft=" + object_name + ".reverseLeft,\nreverseRight=" + object_name + ".reverseRight,\nstop=" + object_name + ".stop,\n"
+    return "forward=" +\
+       object_name +\
+       ".forward,\nreverse=" +\
+       object_name +\
+       ".reverse,\nforwardLeft=" +\
+       object_name +\
+       ".forwardLeft,\nforwardRight=" +\
+       object_name +\
+       ".forwardRight,\nreverseLeft=" +\
+       object_name +\
+       ".reverseLeft,\nreverseRight=" +\
+       object_name +\
+       ".reverseRight,\nstop=" +\
+       object_name +\
+       ".stop,\n"

--- a/roboticsrov/rover_constants.py
+++ b/roboticsrov/rover_constants.py
@@ -1,0 +1,5 @@
+def generate_webcam_hook_string(object_name):
+    return "startVideo=" + object_name + ".start,\nstopVideo=" + object_name + ".end,\n"
+
+def generate_motor_hook_string(object_name):
+    return "forward=" + object_name + ".forward,\nreverse=" + object_name + ".reverse,\nforwardLeft=" + object_name + ".forwardLeft,\nforwardRight=" + object_name + ".forwardRight,\nreverseLeft=" + object_name + ".reverseLeft,\nreverseRight=" + object_name + ".reverseRight,\nstop=" + object_name + ".stop,\n"

--- a/roboticsrov/stream/video_stream.py
+++ b/roboticsrov/stream/video_stream.py
@@ -32,8 +32,7 @@ class VideoStream:
         if (self.streaming):
             print "Stream already up."
         else:
-            print "Starting stream..."
-            print self.stream_args
+            print "Trying stream at ", self.stream_args
             self.stream = subprocess.Popen(self.stream_args)
             self.streaming = True
 

--- a/roboticsrov/umanager.py
+++ b/roboticsrov/umanager.py
@@ -3,7 +3,7 @@ import sys
 import glob
 import time
 
-from roboticsbase_exception import RoboticsbaseException
+from roboticsrov_exception import RoboticsrovException
 
 class UManager:
     # Create the serial connections we need.
@@ -29,7 +29,7 @@ class UManager:
             print index, ": ", port
 
         if not portList:
-            raise RoboticsbaseException("No ports found.") 
+            raise RoboticsrovException("No ports found.") 
         else:
             port_selected = int(raw_input("Select a port: "))
             self.port = portList[port_selected]
@@ -44,7 +44,7 @@ class UManager:
                                 self.timeout)
             print "Connected to port.", self.port
         except:
-            raise RoboticsbaseException("Failed connecting to port.")
+            raise RoboticsrovException("Failed connecting to port.")
 
         print "Waiting some time for microcontroller's serial to startup..."
         time.sleep(5)	# 5 seconds


### PR DESCRIPTION
The rover server is now able to safely start even if the arduino fails to connect. This is done via a system where the rover tries to start each component (so far only the webcam stream and the arduino) separately, and if any exceptions are thrown during initialization, the server is simply started without that component's associated hooks. The hooks that the server starts with are indicated in the server logs, but this could maybe be extended to be returned to the client in the future.

Note: as far as the port connection issue goes, I tested with the arduino and it seems to be successfully closing the port upon server shutdown now, possibly because of a prior change to UManager (whose deconstructor has code to close the port.)